### PR TITLE
changed UK to GB on locales

### DIFF
--- a/app/src/main/java/com/pluscubed/velociraptor/utils/PrefUtils.java
+++ b/app/src/main/java/com/pluscubed/velociraptor/utils/PrefUtils.java
@@ -69,7 +69,7 @@ public abstract class PrefUtils {
         boolean metricDefault;
         Locale current = Locale.getDefault();
         if (current.equals(Locale.US) ||
-                current.equals(Locale.UK) ||
+                current.equals(Locale.GB) ||
                 current.getISO3Country().equalsIgnoreCase("mmr")) {
             metricDefault = false;
         } else {


### PR DESCRIPTION
The correct locale for the United Kingdom is actually GB (for Great Britain.)